### PR TITLE
Add new option 'use_first_line_as_version'

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ This is a useful resource for pipeline development time, while a required artifa
 
 * `skip_ssl_verification`: *Optional.* Skips ssl verification if defined as `true`. Default is `false`.
 
+* `use_first_line_as_version`: *Optional.* Use the first line of the file as the version. Default is `false`.
+
 ### Example
 
 Resource configuration:

--- a/assets/check
+++ b/assets/check
@@ -15,6 +15,7 @@ url=$(jq -r '.source.url // ""' < $payload)
 username=$(jq -r '.source.username // ""' < $payload)
 password=$(jq -r '.source.password // ""' < $payload)
 skip_ssl_verification=$(jq -r '.source.skip_ssl_verification // ""' < $payload)
+use_first_line_as_version=$(jq -r '.source.use_first_line_as_version // ""' < $payload)
 
 if [ -z "$url" ]; then
   echo "invalid payload (missing url)"

--- a/assets/common.sh
+++ b/assets/common.sh
@@ -18,5 +18,11 @@ check_version() {
         local dateString=$(date +"$dateVersionFormat" -D %d\ %b\ %Y\ %H:%M:%S\ GMT -d "$tmpDateString")
   fi
 
-  echo "{\"version\":\"$dateString\"}" | jq --slurp .
+  # Default to the date string
+  local versionValue="$dateString"
+  # Strip out control characters so that jq doesn't get upset
+  local urlContents=$(curl -R -s $1 2>&1 | head -1 | tr -d '[:cntrl:]')
+
+  [ -n "$use_first_line_as_version" ] && versionValue="$urlContents";
+  echo "{\"version\":\"$versionValue\"}" | jq --slurp .
 }

--- a/assets/in
+++ b/assets/in
@@ -25,6 +25,7 @@ filename=$(jq -r '.source.filename // ""' < $payload)
 skip_ssl_verification=$(jq -r '.source.skip_ssl_verification // ""' < $payload)
 username=$(jq -r '.source.username // ""' < $payload)
 password=$(jq -r '.source.password // ""' < $payload)
+use_first_line_as_version=$(jq -r '.source.use_first_line_as_version // ""' < $payload)
 
 if [ -z "$url" ]; then
   echo "invalid payload (missing url)"

--- a/test/test-check.sh
+++ b/test/test-check.sh
@@ -50,6 +50,20 @@ it_can_get_file_with_basic_auth() {
 
 }
 
+it_can_use_first_line_as_the_version() {
+
+  echo $resource_dir
+
+  jq -n "{
+    source: {
+      url: $(echo $FILE_URL_WITHOUT_LAST_MODIFIED_INFO | jq -R .),
+      use_first_line_as_version: true
+    }
+  }" | $resource_dir/check "$FILE_URL_WITHOUT_LAST_MODIFIED_INFO" | tee /dev/stderr
+
+}
+
 run it_can_get_file_with_last_modified_info
 run it_can_get_file_without_last_modified_info
 run it_can_get_file_with_basic_auth
+run it_can_use_first_line_as_the_version

--- a/test/test-in.sh
+++ b/test/test-in.sh
@@ -44,5 +44,17 @@ it_can_get_file_with_basic_auth() {
 
 }
 
+it_can_get_file_and_the_first_line_is_used_as_version() {
+  jq -n "{
+    source: {
+      url: $(echo $FILE_URL_WITHOUT_LAST_MODIFIED_INFO | jq -R .),
+      filename: $(echo $FILE_NAME_1 | jq -R .),
+      use_first_line_as_version: true
+    }
+  }" | $resource_dir/in "$src" | tee /dev/stderr
+
+}
+
 run it_can_get_file_with_date_info
 run it_can_get_file_with_basic_auth
+run it_can_get_file_and_the_first_line_is_used_as_version


### PR DESCRIPTION
* Setting 'use_first_line_as_version' to true sets the
  version to be the first line of the fetched file.
  This is useful for files that contains things
  like a git SHA value.

Signed-off-by: Dick Cavender <dcavender@pivotal.io>