### PR TITLE
Fail `check` if response has error

### DIFF
--- a/assets/common.sh
+++ b/assets/common.sh
@@ -4,7 +4,7 @@ set -e
 # e.g. curl -R -I $1
 check_version() {
   # retrieves HTTP header of file URL response
-  local httpHeader=$(curl -R -I $1 2>&1 | grep 'Last-Modified:')
+  local httpHeader=$(curl -R -I -f $1 2>&1 | grep 'Last-Modified:')
   # Checks if field "Last-Modified" exists in HTTP header and transform it into timestamp string
   # if that field is not present, return current timestamp
   local dateVersionFormat="%Y%m%d%H%S"


### PR DESCRIPTION
Currently check returns version if response has error http code.
This causes invalid response at `in`.

This PR fixes this issue.

Signed-off-by: OTSUKA, Yuanying <mototsuk@zlab.co.jp>